### PR TITLE
style(faculty): riduce dimensione immagini (~50%) e centra responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,15 +347,31 @@
             box-shadow: 0 25px 50px rgba(0,0,0,0.15);
         }
 
-        .faculty-image {
-            width: 100%;
+        .faculty-card .faculty-image {
+            width: 50%;
+            max-width: 220px;
             height: auto;
             display: block;
-            object-fit: cover;
+            margin: 24px auto 0;
+            object-fit: contain;
         }
 
         .faculty-image::after {
             content: none;
+        }
+
+        @media (max-width: 992px) {
+            .faculty-card .faculty-image {
+                width: 60%;
+                max-width: 200px;
+            }
+        }
+
+        @media (max-width: 600px) {
+            .faculty-card .faculty-image {
+                width: 70%;
+                max-width: 180px;
+            }
         }
 
         .faculty-role-badge {


### PR DESCRIPTION
## Summary
- aggiorna le regole CSS di `.faculty-image` per ridurre la larghezza al 50% su desktop
- aggiunge margine e object-fit contain per centrare le immagini e mantenerne le proporzioni
- introduce breakpoint a 992px e 600px per dimensioni più contenute su tablet e mobile

## Testing
- non sono stati eseguiti test automatici

------
https://chatgpt.com/codex/tasks/task_e_68d6b02693f08322a4ca9d66b03eb07c