### PR TITLE
feat(forms): invio reale via FormSubmit + messaggio di conferma

### DIFF
--- a/index.html
+++ b/index.html
@@ -1491,7 +1491,12 @@
             <span class="close-modal" onclick="closeStudentModal()">&times;</span>
             <h2>Informazioni per Studenti</h2>
             
-            <form class="info-form" action="mailto:virgilio.maretto@posti.world" method="post" enctype="text/plain" onsubmit="submitStudentForm(event)">
+            <form class="info-form" method="POST" action="https://formsubmit.co/virgilio.maretto@posti.world">
+                <input type="hidden" name="_subject" value="Richiesta informazioni - Master Carbon Farming">
+                <input type="hidden" name="_captcha" value="false">
+                <input type="hidden" name="_template" value="table">
+                <input type="hidden" name="_next" value="https://vmaretto.github.io/unitus-carbon-farming/?sent=1#grazie">
+                <input type="text" name="_honey" style="display:none">
                 <div class="form-group">
                     <label>Nome e Cognome *</label>
                     <input type="text" name="nome" required>
@@ -1597,7 +1602,12 @@
                 </div>
             </div>
             
-            <form class="sponsor-contact-form" onsubmit="submitSponsorForm(event)">
+            <form class="sponsor-contact-form" method="POST" action="https://formsubmit.co/virgilio.maretto@posti.world">
+                <input type="hidden" name="_subject" value="Richiesta partnership - Master Carbon Farming">
+                <input type="hidden" name="_captcha" value="false">
+                <input type="hidden" name="_template" value="table">
+                <input type="hidden" name="_next" value="https://vmaretto.github.io/unitus-carbon-farming/?sent=1#grazie">
+                <input type="text" name="_honey" style="display:none">
                 <h3>Richiedi informazioni dettagliate</h3>
                 
                 <div class="form-row">
@@ -2584,36 +2594,6 @@
             document.getElementById('sponsorInfoModal').style.display = 'none';
         }
 
-        function submitStudentForm(event) {
-            event.preventDefault();
-            const formData = new FormData(event.target);
-            const data = Object.fromEntries(formData);
-
-            const subject = encodeURIComponent("Richiesta informazioni - Master Carbon Farming");
-            const body = encodeURIComponent(
-                `Nome: ${data.nome}\nEmail: ${data.email}\nTelefono: ${data.telefono || "-"}\nTitolo: ${data.titolo}\nInteressi: ${data.interessi || "-"}`
-            );
-            window.location.href = `mailto:virgilio.maretto@posti.world?subject=${subject}&body=${body}`;
-            alert(`Grazie ${data.nome}! La tua richiesta è stata inviata. Ti contatteremo all'indirizzo ${data.email}.`);
-            closeStudentModal();
-            event.target.reset();
-        }
-
-        function submitSponsorForm(event) {
-            event.preventDefault();
-            const formData = new FormData(event.target);
-            const data = Object.fromEntries(formData);
-
-            const subject = encodeURIComponent("Richiesta partnership - Master Carbon Farming");
-            const body = encodeURIComponent(
-                `Azienda/Ente: ${data.azienda}\nReferente: ${data.referente}\nEmail: ${data.email}\nTelefono: ${data.telefono || "-"}\nPacchetto: ${data.pacchetto || "-"}\nNote: ${data.note || "-"}`
-            );
-            window.location.href = `mailto:virgilio.maretto@posti.world?subject=${subject}&body=${body}`;
-            alert(`Grazie ${data.referente} di ${data.azienda}! La vostra richiesta è stata inviata. Vi contatteremo a ${data.email}.`);
-            closeSponsorModal();
-            event.target.reset();
-        }
-
         function downloadBrochure() {
             alert('📄 La brochure del Master in Carbon Farming sarà disponibile per il download a breve. Contatta master.carbonfarming@unitus.it per ricevere il materiale informativo completo.');
         }
@@ -2709,6 +2689,20 @@
                 });
             }
         });
+
+        (function () {
+            const params = new URLSearchParams(window.location.search);
+            if (params.get('sent') === '1') {
+                const box = document.getElementById('grazie');
+                if (box) box.style.display = 'block';
+                if (typeof closeStudentModal === 'function') closeStudentModal();
+                if (typeof closeSponsorModal === 'function') closeSponsorModal();
+                if (history.replaceState) {
+                    const url = window.location.href.replace('?sent=1', '').replace('&sent=1', '');
+                    history.replaceState({}, '', url);
+                }
+            }
+        })();
     </script>
 
     <div id="cookieBanner" class="cookie-banner" style="display:none;">
@@ -2720,6 +2714,10 @@
             <button id="cookieAccept" class="cookie-btn">Accetta</button>
             <button id="cookieReject" class="cookie-btn ghost">Rifiuta</button>
         </div>
+    </div>
+
+    <div id="grazie" style="display:none;text-align:center;padding:16px 12px;margin:20px auto;max-width:900px;border-radius:12px;background:#e8f5e8;border:1px solid #cfe8cf;color:#2c5f2d;font-weight:600;">
+        ✅ Grazie! La tua richiesta è stata inviata correttamente. Ti contatteremo a breve.
     </div>
 </body>
 </html>


### PR DESCRIPTION
Entrambi i form ora POSTano a FormSubmit (virgilio.maretto@posti.world) con subject dedicati, honeypot e redirect di conferma; rimosse frasi “entro 48 ore” e gli alert JS. Nessun file binario aggiunto.

------
https://chatgpt.com/codex/tasks/task_e_68d6d6966f548322a0bd8481b92547b8