### PR TITLE
fix(overview): immagine intera in sezione “Un Master per il futuro sostenibile”

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,12 +245,12 @@
         .overview-img {
             width: 100%;
             max-width: 500px;
-            height: 350px;
+            height: auto;              /* si adatta al contenuto */
             border-radius: 20px;
             overflow: hidden;
             box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             margin: 0 auto;
-            background: #2c5f2d; /* fallback neutro */
+            background: #2c5f2d;       /* fallback colore */
             position: relative;
         }
 
@@ -260,9 +260,10 @@
 
         .overview-figure {
             width: 100%;
-            height: 100%;
-            object-fit: cover;   /* se vuoi vedere tutta l’immagine senza tagli: usa "contain" */
+            height: auto;
             display: block;
+            object-fit: contain;       /* mostra tutta l’immagine intera */
+            background: #2c5f2d;       /* riempie lo spazio vuoto */
         }
 
         /* What You Will Learn Section */


### PR DESCRIPTION
Modificato CSS per mostrare l’immagine MasterFuturoSostenibile.png con object-fit: contain, senza tagliarla; reso il box responsive con altezza auto e colore di background di fallback. Nessun file binario aggiunto.

------
https://chatgpt.com/codex/tasks/task_e_68d700804bac8322b8db64d728d93351